### PR TITLE
switch VAULTPAL_COMMIT and VAULTAL_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
       -
         name: Set Variables used in .goreleaser.yml for ldflags
         run: |
-           echo "VAULTPAL_VERSION=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-           echo "VAULTPAL_COMMIT=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
+           echo "VAULTPAL_COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+           echo "VAULTPAL_VERSION=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
@pschulten sorry, the variables where mixed up, so the version shows the commit hash. I already had this fixed locally when I created the PR, but forgot to push the the last commit to remote. Now it should work!   
 
```
          { vault~Pal 👍 }
         °- (🕶 ) 57ab3b5 -°
```