### PR TITLE
Reduce platform binaries, improve version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,4 +98,4 @@ jobs:
           build-args: |
             VAULTPAL_COMMIT=${{ env.VAULTPAL_COMMIT }}
             VAULTPAL_VERSION=${{ env.VAULTPAL_VERSION }}
-            VAULTPAL_BUILD_DATE=${{ env.BUILD_DATE }}
+            VAULTPAL_BUILD_DATE=${{ env.VAULTPAL_BUILD_DATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
            echo "VAULTPAL_COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
            echo "VAULTPAL_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
+           echo "VAULTPAL_BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_ENV"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
@@ -60,6 +61,7 @@ jobs:
         run: |
           echo "VAULTPAL_COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
           echo "VAULTPAL_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
+          echo "VAULTPAL_BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_ENV"
       -
         name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -96,3 +98,4 @@ jobs:
           build-args: |
             VAULTPAL_COMMIT=${{ env.VAULTPAL_COMMIT }}
             VAULTPAL_VERSION=${{ env.VAULTPAL_VERSION }}
+            VAULTPAL_BUILD_DATE=${{ env.BUILD_DATE }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
       - "6"
       - "7"
     ldflags:
-      - -s -w -X github.com/dbschenker/vaultpal/cmd.Version={{.Env.VAULTPAL_VERSION}} -X github.com/dbschenker/vaultpal/cmd.Commit={{.Env.VAULTPAL_COMMIT}}
+      - -s -w -X github.com/dbschenker/vaultpal/cmd.Version={{.Env.VAULTPAL_VERSION}} -X github.com/dbschenker/vaultpal/cmd.Commit={{.Env.VAULTPAL_COMMIT}} -X github.com/dbschenker/vaultpal/cmd.BuildDate={{.Env.VAULTPAL_BUILD_DATE}}
 archives:
   - format: zip
     files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,9 +15,11 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - "6"
-      - "7"
+    # (...) with GOARCH=arm64 do not need to set a variable GOARM (only with GOARCH=arm)
+    # https://github.com/goreleaser/goreleaser/issues/36
+    # goarm:
+    #  - "6"
+    #  - "7"
     ldflags:
       - -s -w -X github.com/dbschenker/vaultpal/cmd.Version={{.Env.VAULTPAL_VERSION}} -X github.com/dbschenker/vaultpal/cmd.Commit={{.Env.VAULTPAL_COMMIT}} -X github.com/dbschenker/vaultpal/cmd.BuildDate={{.Env.VAULTPAL_BUILD_DATE}}
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,7 @@ builds:
       - darwin
       - windows
     goarch:
-      - "386"
       - amd64
-      - arm
       - arm64
     goarm:
       - "6"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,8 @@
+# Use the following command for local testing (only creates binaries in local dist/ directory)
+# VAULTPAL_VERSION=latest VAULTPAL_BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%S') ˜
+# VAULTPAL_COMMIT=$(git log -1 --pretty=format:%h) \
+# goreleaser build --clean --skip-validate --snapshot
+
 before:
   hooks:
     - go mod tidy
@@ -15,11 +20,9 @@ builds:
     goarch:
       - amd64
       - arm64
-    # (...) with GOARCH=arm64 do not need to set a variable GOARM (only with GOARCH=arm)
+    # (...) if we only have GOARCH=arm64, we do not need to set a variable GOARM
     # https://github.com/goreleaser/goreleaser/issues/36
-    # goarm:
-    #  - "6"
-    #  - "7"
+    # goarm: ["6", "7"]
     ldflags:
       - -s -w -X github.com/dbschenker/vaultpal/cmd.Version={{.Env.VAULTPAL_VERSION}} -X github.com/dbschenker/vaultpal/cmd.Commit={{.Env.VAULTPAL_COMMIT}} -X github.com/dbschenker/vaultpal/cmd.BuildDate={{.Env.VAULTPAL_BUILD_DATE}}
 archives:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.20 as builder
 # Build arguments for this image (used as -X args in ldflags)
 ARG VAULTPAL_VERSION=""
 ARG VAULTPAL_COMMIT=""
+ARG VAULTPAL_BUILD_DATE=""
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 go build \
   -ldflags="-w -s \
   -X 'github.com/dbschenker/vaultpal/cmd.Version=${VAULTPAL_VERSION}' \
   -X 'github.com/dbschenker/vaultpal/cmd.Commit=${VAULTPAL_COMMIT}' \
+  -X 'github.com/dbschenker/vaultpal/cmd.BuildDate=${VAULTPAL_BUILD_DATE}' \
   -extldflags '-static'" \
   -a -o main .
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ var cfgFile string
 // The verbose flag value
 var v string
 
-// overwrite with go build -ldflags="-X github.com/dbschenker/vaultpal/cmd.Version=<VERSION>"
+// Version can be set with go build -ldflags="-X github.com/dbschenker/vaultpal/cmd.Version=<VERSION>"
 var Version = "v.latest"
 var Commit = "unknown"
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"io"
 	"os"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -80,6 +81,7 @@ var v string
 // Version can be set with go build -ldflags="-X github.com/dbschenker/vaultpal/cmd.Version=<VERSION>"
 var Version = "v.latest"
 var Commit = "unknown"
+var BuildDate = time.Now().Format(time.RFC3339)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,7 @@ func newVersionCmd() *cobra.Command {
 
 vaultpal version`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var msg = fmt.Sprintf("%s (commit: %s)", Version, Commit)
+			var msg = fmt.Sprintf("%s (commit: %s), built %s", Version, Commit, BuildDate)
 			println(msg)
 		},
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"runtime"
 )
 
 func newVersionCmd() *cobra.Command {
@@ -13,7 +14,8 @@ func newVersionCmd() *cobra.Command {
 
 vaultpal version`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var msg = fmt.Sprintf("%s (commit: %s), built %s", Version, Commit, BuildDate)
+			var msg = fmt.Sprintf("%s (commit: %s), built %s, platform %s/%s",
+				Version, Commit, BuildDate, runtime.GOOS, runtime.GOARCH)
 			println(msg)
 		},
 	}


### PR DESCRIPTION
Fixes #32, new goreleaser config would produce only the following 6 binaries. 

```
$ goreleaser release --clean --skip-publish --skip-validate
  • building binaries
    • building                                       binary=dist/vaultpal_windows_arm64/vaultpal.exe
    • building                                       binary=dist/vaultpal_linux_amd64_v1/vaultpal
    • building                                       binary=dist/vaultpal_darwin_amd64_v1/vaultpal
    • building                                       binary=dist/vaultpal_windows_amd64_v1/vaultpal.exe
    • building                                       binary=dist/vaultpal_darwin_arm64/vaultpal
    • building                                       binary=dist/vaultpal_linux_arm64/vaultpal
``` 

Also adds build date and platform info to version output. Docker multi-platform build will be adapted with a separate MR