### PR TITLE
Update package.yml make sure upload-artifact and download-artifact use the same version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,7 +84,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload image digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests
           path: /tmp/digests/*
@@ -101,7 +101,7 @@ jobs:
     steps:
       -
         name: Download image digests
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests


### PR DESCRIPTION
Apparently dependabot only updated download-artifact to v4, which in turn isn't compatible with upload-artifact v3, see https://github.com/dbschenker/vaultpal/actions/runs/11361070100

```
 merge-manifests
Unable to download artifact(s): Artifact not found for name: digests Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact. For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```


