### PR TITLE
Add PLATFORM_PAIR suffix to distinguish between platform specific digest artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,6 +22,11 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
+      - 
+        name: Prepare PLATFORM_PAIR var for upload-artifact
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -86,7 +91,9 @@ jobs:
         name: Upload image digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          # as of upload-artifact@v4, artifact name must be unique (and must NOT contain a slash :-))
+          # https://docs.docker.com/build/ci/github-actions/multi-platform/
+          name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -100,11 +107,12 @@ jobs:
       - ghcr-releaser
     steps:
       -
-        name: Download image digests
+        name: Download PLATFORM_PAIR specific image digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
           path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
       -
         name: Set up Docker Buildx # but no need for QEMU in this job
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
As of upload-artifact@v4, artifact names must be unique (and must NOT contain a slash), see  https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes.

Workflow code has been updated according to the official example https://docs.docker.com/build/ci/github-actions/multi-platform/, using the variable `PLATFORM_PAIR` to distinguish between the platform specific digest artifacts, which can be merged later according to the common pattern prefix.

Failed Pipeline: https://github.com/dbschenker/vaultpal/actions/runs/11380710907/job/31660558004#step:10:33