### PR TITLE
Use docker 1.23

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
 #        platform: [ubuntu-latest, macos-latest, windows-latest]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
 #        platform: [ubuntu-latest, macos-latest, windows-latest]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 AS builder
 
 # Build arguments for this image (used as -X args in ldflags)
 ARG VAULTPAL_VERSION=""


### PR DESCRIPTION
fix https://github.com/dbschenker/vaultpal/actions/runs/12669183777/job/35306331268#step:9:276
```
#11 0.893 go: go.mod requires go >= 1.23.0 (running go 1.22.10; GOTOOLCHAIN=local)
#11 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
------
 > [builder 4/6] RUN go mod download:
0.893 go: go.mod requires go >= 1.23.0 (running go 1.22.10; GOTOOLCHAIN=local)
```
