### PR TITLE
Support region specific AWS console destination URL if AWS_REGION is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ vaultpal provides a bash alias function to wrap the vaultpal command with direct
     ```
 ### Export AWS web console URL to shell
 
-1. Use vaultpal to create temporary sign-in URLs to access the AWS Web Console with a single click
+1. Use vaultpal to create temporary sign-in URLs to access the AWS Web Console with a single click. If the environment variable AWS_REGION is set, the URL will redirect to the region specific console URL.
    ```
    vaultpal -v warn export awsconsole myapp-prod-admin
    https://signin.aws.amazon.com/federation?Action=login&Issuer=https://(...)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/dbschenker/vaultpal
 
-go 1.23.0
-toolchain go1.24.1
+go 1.24.0
+
+toolchain go1.24.3
 
 // STILL NEEDED FOR INTELLIJ ?
 //replace github.com/SAP/go-hdb => github.com/SAP/go-hdb v1.8.11

--- a/timer/token_timer.go
+++ b/timer/token_timer.go
@@ -187,21 +187,21 @@ func output(ttl time.Duration, carriageReturn bool, label string, query bool) {
 		if query {
 			fmt.Println(Green)
 		} else {
-			_, _ = info.Printf(msg)
+			_, _ = info.Println(msg)
 		}
 
 	case factor <= 50 && factor >= 10:
 		if query {
 			fmt.Println(Yellow)
 		} else {
-			_, _ = warn.Printf(msg)
+			_, _ = warn.Println(msg)
 		}
 
 	default:
 		if query {
 			fmt.Println(Red)
 		} else {
-			_, _ = crit.Printf(msg)
+			_, _ = crit.Println(msg)
 		}
 	}
 }


### PR DESCRIPTION
The default AWS region based on browser storage does not work reliably when using federated sign-in. This PR introduces region specific console destination URLs if AWS_REGION is present in the current environment (for example https://eu-central-1.console.aws.amazon.com instead of https://console.aws.amazon.com).