### PR TITLE
Use Go 1.26 in docker build, remove DB from README

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
 #        platform: [ubuntu-latest, macos-latest, windows-latest]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
 #        platform: [ubuntu-latest, macos-latest, windows-latest]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Build arguments for this image (used as -X args in ldflags)
 ARG VAULTPAL_VERSION=""

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vaultpal :vulcan_salute:
 > { your pal for using vault }
 
-At DB Schenker, we use [HashiCorp Vault](https://www.vaultproject.io/) extensively to automate access to secrets
+At Schenker, we use [HashiCorp Vault](https://www.vaultproject.io/) extensively to automate access to secrets
 (e.g. application credentials), and systems such as *Kubernetes* or *AWS*. 
 
 Even though the official Vault CLI and the [HTTP API](https://developer.hashicorp.com/vault/api-docs) provide the necessary 


### PR DESCRIPTION
Last release failed: https://github.com/dbschenker/vaultpal/actions/runs/29562684966/job/87828980698
